### PR TITLE
Manually install docker, docker-compose on clean AMI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ before_install:
 
 script:
   - ./terraform init --backend-config="key=unstable/terraform.tfstate" -var aws_access_key=${AWS_ACCESS_KEY_ID} -var aws_secret_key=${AWS_SECRET_ACCESS_KEY}
-  - ./terraform plan -var aws_access_key=${AWS_ACCESS_KEY_ID} -var aws_secret_key=${AWS_SECRET_ACCESS_KEY}
+  - ./terraform plan -var aws_access_key=${AWS_ACCESS_KEY_ID} -var aws_secret_key=${AWS_SECRET_ACCESS_KEY} -out /tmp/terraform.plan
 
 deploy:
 - provider: script
   script:
-    - ./terraform apply -var aws_access_key=${AWS_ACCESS_KEY_ID} -var aws_secret_key=${AWS_SECRET_ACCESS_KEY}
+    - ./terraform apply -var aws_access_key=${AWS_ACCESS_KEY_ID} -var aws_secret_key=${AWS_SECRET_ACCESS_KEY} /tmp/terraform.plan
   skip_cleanup: true
   on:
     branch: master

--- a/tf/install-docker.sh
+++ b/tf/install-docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+sudo apt-get update
+sudo apt-get -y install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common \
+    git
+
+# docker
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable"
+sudo apt-get update
+sudo apt-get install -y docker-ce
+
+# docker-compose
+wget -O /tmp/docker-compose https://github.com/docker/compose/releases/download/1.21.2/docker-compose-Linux-x86_64
+chmod +x /tmp/docker-compose
+sudo mv /tmp/docker-compose /usr/local/bin/docker-compose
+
+# ubuntu user
+sudo usermod -a -G docker ubuntu

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -1,8 +1,9 @@
 resource "aws_instance" "single_node" {
-  # This is the latest minimal version of Amazon Linux coupled with ECS container agent, Docker and ecs-init scripts
-  # see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-  ami             = "ami-00129b193dc81bc31"
-  instance_type   = "t2.micro"
+
+  # us-east-1 bionic 18.04 LTS amd64 hvm:ebs-ssd 20180912                    
+  # https://cloud-images.ubuntu.com/locator/ec2/
+  ami = "ami-0ac019f4fcb7cb7e6"
+  instance_type = "t2.micro"
   subnet_id = "${var.subnet_id}"
   vpc_security_group_ids = ["${aws_security_group.single_node.id}"]
   associate_public_ip_address = true
@@ -10,6 +11,16 @@ resource "aws_instance" "single_node" {
 
   tags {
     Name = "single-node--${var.env}"
+  }
+
+  provisioner "remote-exec" {
+    script = "install-docker.sh"
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      private_key = "${file("single-node--${var.env}.key")}"
+    }
   }
 }
 
@@ -69,3 +80,4 @@ resource "aws_key_pair" "single_node" {
 data "local_file" "public_key" {
   filename = "single-node--${var.env}.key.pub"
 }
+


### PR DESCRIPTION
The previous AMI has a continuously crashing ecs-agent container:

``` CONTAINER ID        IMAGE                            COMMAND CREATED
         STATUS                  PORTS               NAMES dae2c68db666
   amazon/amazon-ecs-agent:latest   "/agent" 1 second ago        Up Less
than a second ecs-agent
```

plus some other unknowns on processes meant for Elastic Container Service
rather than for generic Docker usage. For example, it seems to use 400MB of
RAM vs. the <150MB of a plain Ubuntu image.