### PR TITLE
Turn on T2 unlimited

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -8,6 +8,9 @@ resource "aws_instance" "single_node" {
   vpc_security_group_ids = ["${aws_security_group.single_node.id}"]
   associate_public_ip_address = true
   key_name = "${aws_key_pair.single_node.key_name}"
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
 
   tags {
     Name = "single-node--${var.env}"


### PR DESCRIPTION
`unstable` is experiencing high load and ~80% CPU steal which indicates
CPU credits are consumed, but not replenished by periods of low activity:
```
top - 10:14:50 up 68 days, 20:26,  1 user,  load average: 10.83, 11.57,
9.00
Tasks: 165 total,   8 running, 122 sleeping,   0 stopped,   2 zombie
%Cpu(s): 19.0 us,  7.9 sy,  0.0 ni,  0.0 id,  0.0 wa,  0.0 hi,  0.0 si,
73.1 st
```
This is a [classic problem for T2 instances on
AWS](https://aws.amazon.com/blogs/aws/new-t2-unlimited-going-beyond-the-burst-with-high-performance/), cheap but throttled often in this way.

This results in the T2 instance automatically being billed at an higher
price to allow full usage of the CPU.