### PR TITLE
Expand disk size as we are over the 85% mark

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -13,6 +13,7 @@ resource "aws_instance" "single_node" {
   }
 
   root_block_device {
+    volume_type = "standard"
     volume_size = 20
   }
 

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -13,6 +13,7 @@ resource "aws_instance" "single_node" {
   }
 
   root_block_device {
+    volume_type = "gp2"
     volume_size = 20
   }
 

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -13,7 +13,6 @@ resource "aws_instance" "single_node" {
   }
 
   root_block_device {
-    volume_type = "gp2"
     volume_size = 20
   }
 

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -12,6 +12,10 @@ resource "aws_instance" "single_node" {
     cpu_credits = "unlimited"
   }
 
+  root_block_device {
+    volume_size = 20
+  }
+
   tags {
     Name = "single-node--${var.env}"
   }


### PR DESCRIPTION
See https://github.com/libero/libero/issues/154#issuecomment-501636489

This will force recreating the instance from scratch, losing all state (which is just demo data). In theory the disk should be expandable, not sure if it's because it's the root volume or because it is magnetic.