### PR TITLE
Increase machine size to t2.xlarge

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -3,7 +3,7 @@ resource "aws_instance" "single_node" {
   # us-east-1 bionic 18.04 LTS amd64 hvm:ebs-ssd 20180912                    
   # https://cloud-images.ubuntu.com/locator/ec2/
   ami = "ami-0ac019f4fcb7cb7e6"
-  instance_type = "t2.medium"
+  instance_type = "t2.xlarge"
   subnet_id = "${var.subnet_id}"
   vpc_security_group_ids = ["${aws_security_group.single_node.id}"]
   associate_public_ip_address = true


### PR DESCRIPTION
Quick fix for https://github.com/libero/libero/issues/191

Terraform is able to do this via a reboot rather than re-creating the instance.