### PR TITLE
Add Travis CI to Kubernetes access

### DIFF
--- a/tf/envs/variables.tf
+++ b/tf/envs/variables.tf
@@ -14,6 +14,11 @@ variable "map_users" {
       username = "GiorgioSironi"
       groups   = ["system:masters"]
     },
+    {
+      userarn  = "arn:aws:iam::540790251273:user/TravisCI"
+      username = "TravisCI"
+      groups   = ["system:masters"]
+    },
   ]
   description = "IAM users that can access the cluster"
 }


### PR DESCRIPTION
Otherwise `terraform plan` fails when setting up the `kubernetes` provider.

Follow-up to https://github.com/libero/infrastructure/pull/43