### PR TITLE
Install and smoke test Helm during deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/helm
 /tf/.terraform
 /tf/terraform
 /tf/*.plan

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     on:
       tags: true
   - provider: script
-    script: scripts/terraform-apply.sh franklin && aws eks update-kubeconfig libero-eks--franklin && ./helm ls
+    script: ../scripts/terraform-apply.sh franklin && aws eks update-kubeconfig libero-eks--franklin && ./helm ls
     skip_cleanup: true
     on:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     on:
       tags: true
   - provider: script
-    script: cd envs/franklin && rm -rf .terraform && ../../terraform init --backend-config="key=franklin/terraform.tfstate" -input=false && ../../terraform apply /tmp/franklin.plan
+    script: scripts/terraform-apply.sh franklin && aws eks update-kubeconfig libero-eks--franklin && helm ls
     skip_cleanup: true
     on:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     on:
       tags: true
   - provider: script
-    script: ../scripts/terraform-apply.sh franklin && aws eks update-kubeconfig libero-eks--franklin && ./helm ls
+    script: ../scripts/terraform-apply.sh franklin && aws eks update-kubeconfig --name libero-eks--franklin && ../helm ls
     skip_cleanup: true
     on:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ deploy:
     on:
       tags: true
   - provider: script
-    script: scripts/terraform-apply.sh franklin && aws eks update-kubeconfig libero-eks--franklin && helm ls
+    script: scripts/terraform-apply.sh franklin && aws eks update-kubeconfig libero-eks--franklin && ./helm ls
     skip_cleanup: true
     on:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - TRAVIS_KEY=$encrypted_656a7d042f6e_key TRAVIS_IV=$encrypted_656a7d042f6e_iv .scripts/travis/git-crypt-unlock.sh travis-ci.key.enc
   - bash -c '[ "$(head -n 1 tf/registration--unstable.key)" == "-----BEGIN RSA PRIVATE KEY-----" ]'
   - scripts/download-terraform.sh
+  - scripts/download-helm.sh
   - sudo apt-add-repository --yes --update ppa:ansible/ansible
   - sudo apt-get install ansible
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,21 @@ ssh -i "tf/single-node--${ENVIRONMENT_NAME}.key" ubuntu@$(./terraform output sin
 
 ### Kubectl access
 
+Assuming you have AWS credentials setup to access the Libero account, the `aws` cli can generate your `kubectl` authentication configuration for the cluster:
+
 ```
 aws eks update-kubeconfig libero-eks--franklin
 kubectl version
 kubectl get pods
+```
+
+### Helm access
+
+Helm uses the same authentication as `kubectl`. Use the Helm version provided by this repository.
+
+```
+scripts/download-helm.sh
+helm ls
 ```
 
 ## Admin

--- a/scripts/download-helm.sh
+++ b/scripts/download-helm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+HELM_VERSION="${HELM_VERSION:-3.0.1}"
+archive="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+
+wget "https://get.helm.sh/${archive}"
+tar xvzf "${archive}" --strip-components=1 linux-amd64/helm
+rm "${archive}"

--- a/scripts/terraform-apply.sh
+++ b/scripts/terraform-apply.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ "$#" -eq 1 ]; then
+if [ "$#" -lt 1 ]; then
     echo "Usage: scripts/terraform-apply.sh ENVIRONMENT"
     echo "Example: scripts/terraform-apply.sh franklin"
     exit 1

--- a/scripts/terraform-apply.sh
+++ b/scripts/terraform-apply.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -eq 1 ]; then
+    echo "Usage: scripts/terraform-apply.sh ENVIRONMENT"
+    echo "Example: scripts/terraform-apply.sh franklin"
+    exit 1
+fi
+
+environment="${1}"
+
+cd "envs/${environment}"
+rm -rf .terraform
+../../terraform init \
+    --backend-config="key=${environment}/terraform.tfstate" \
+    -input=false
+../../terraform apply "/tmp/${environment}.plan"


### PR DESCRIPTION
Main part of https://github.com/libero/publisher/issues/359. Helm 3 doesn't require to install anything on the cluster; so we just download it and configure it to access the cluster, listing the releases that are present.