### PR TITLE
Use default namespace

### DIFF
--- a/tf/envs/main.tf
+++ b/tf/envs/main.tf
@@ -48,7 +48,6 @@ module "kubernetes_dns" {
   source = "../../modules/kubernetes_dns"
   role_name = module.kubernetes_cluster.worker_iam_role_name
   domain_name = "libero.pub"
-  namespace = "publisher"
   owner_id = "libero-eks--${var.env}"
 }
 

--- a/tf/modules/kubernetes_dns/variables.tf
+++ b/tf/modules/kubernetes_dns/variables.tf
@@ -4,6 +4,7 @@ variable "domain_name" {
 
 variable "namespace" {
   description = "Kubernetes namespace, e.g. default"
+  default = "default"
 }
 
 variable "owner_id" {


### PR DESCRIPTION
Removes the `publisher` Kubernetes namespace in favour of just `default`.