### PR TITLE
Pin Terraform version and move to 0.12.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: bash
 
 env:
   global:
-    - TERRAFORM_VERSION=0.12.17
     - TERRAFORM=../../terraform
 
 branches:

--- a/scripts/download-terraform.sh
+++ b/scripts/download-terraform.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-TERRAFORM_VERSION="${TERRAFORM_VERSION:-0.11.14}"
+TERRAFORM_VERSION="0.12.21"
 archive="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 
 cd tf


### PR DESCRIPTION
Fixes misalignment of Terraform versions, and moves to 0.12.21 (caused by an `apply` in https://github.com/libero/infrastructure/pull/49).