### PR TITLE
Use released terraform-aws-eks version

### DIFF
--- a/tf/envs/main.tf
+++ b/tf/envs/main.tf
@@ -2,6 +2,7 @@ provider "aws" {
   region = var.region
 }
 
+# Needed for the terraform-aws-eks module to create the aws-auth ConfigMap
 provider "kubernetes" {
   host = module.kubernetes_cluster.kubernetes_config.host
   cluster_ca_certificate = module.kubernetes_cluster.kubernetes_config.cluster_ca_certificate

--- a/tf/modules/kubernetes_cluster/main.tf
+++ b/tf/modules/kubernetes_cluster/main.tf
@@ -12,12 +12,8 @@ resource "aws_security_group" "node_port_services_public_access" {
 }
 
 module "eks" {
-  # master, unreleased 8.x
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eks.git?ref=11d8ee8631ec2bb98d85295d814a4dc738026704"
-  # TODO: transition to the following
-  # when a 8.x release is available
-  #source  = "terraform-aws-modules/eks/aws"
-  #version = "7.0.0"
+  source  = "terraform-aws-modules/eks/aws"
+  version = "8.2.0"
 
   cluster_name = var.cluster_name
   vpc_id = var.vpc_id


### PR DESCRIPTION
Uses a released version rather than building from source; also adds a comment regarding the `kubernetes` provider.